### PR TITLE
create qbean only once

### DIFF
--- a/src/main/java/br/ufsc/bridge/querydsl/selection/Select.java
+++ b/src/main/java/br/ufsc/bridge/querydsl/selection/Select.java
@@ -155,7 +155,9 @@ public class Select<T> implements SelectExpression<T>, FactoryExpression<T> {
 
 	@Override
 	public List<Expression<?>> getArgs() {
-		this.qbean = (FactoryExpressionBase<T>) this.createSelection();
+		if(qbean == null) {
+			this.qbean = (FactoryExpressionBase<T>) this.createSelection();
+		}
 		return this.qbean.getArgs();
 	}
 


### PR DESCRIPTION
Essa alteração impede de recriar os metadados do reflection para cada row do select, aumentando a performance em aproximadamente 96%, ou seja, nos testes passou de 116ms para 4ms